### PR TITLE
Added ignore missing field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ GET my-index/doc/2
 
 | Parameter | Use |
 | --- | --- |
-| field         | Field name of where to read the content from |
-| target_field  | Field name to write the language to |
-| max_length    | Max length of of characters to read, defaults to 10kb, requires a byte size value, like 1mb |
+| field          | Field name of where to read the content from |
+| target_field   | Field name to write the language to |
+| max_length     | Max length of of characters to read, defaults to 10kb, requires a byte size value, like 1mb |
+| ignore_missing | Ignore missing source field. Not throwing exception in that case. Expects for boolean value, defaults to false. |
 
 ## Setup
 

--- a/src/test/java/org/elasticsearch/plugin/ingest/langdetect/LangDetectProcessorTests.java
+++ b/src/test/java/org/elasticsearch/plugin/ingest/langdetect/LangDetectProcessorTests.java
@@ -44,6 +44,7 @@ public class LangDetectProcessorTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "source_field");
         config.put("target_field", "language");
+        config.put("ignore_missing", false);
 
         Map<String, Object> data = ingestDocument(config,
                 "source_field", "This is hopefully an english text, that will be detected.");
@@ -56,6 +57,7 @@ public class LangDetectProcessorTests extends ESTestCase {
         config.put("field", "source_field");
         config.put("target_field", "language");
         config.put("max_length", "20b");
+        config.put("ignore_missing", false);
 
         // a document with a lot of german text at the end, that should be ignored due to max length
         // copied from https://de.wikipedia.org/wiki/Unwetter_in_Mitteleuropa_2016
@@ -81,4 +83,3 @@ public class LangDetectProcessorTests extends ESTestCase {
         return ingestDocument.getSourceAndMetadata();
     }
 }
-

--- a/src/test/java/org/elasticsearch/plugin/ingest/langdetect/LangDetectProcessorTests.java
+++ b/src/test/java/org/elasticsearch/plugin/ingest/langdetect/LangDetectProcessorTests.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
 
 public class LangDetectProcessorTests extends ESTestCase {
 
@@ -71,6 +72,18 @@ public class LangDetectProcessorTests extends ESTestCase {
                 "source_field", "This is hopefully an english text, that will be detected. " + germanText);
 
         assertThat(data, hasEntry("language", "en"));
+    }
+
+    public void testIgnoreMissingConfiguration() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "missing_source_field");
+        config.put("target_field", "language");
+        config.put("ignore_missing", true);
+
+        Map<String, Object> data = ingestDocument(config,
+                "source_field", "This is hopefully an english text, that will be detected.");
+
+        assertThat(data, not(hasEntry("language", "en")));
     }
 
     private Map<String, Object> ingestDocument(Map<String, Object> config, String field, String value) throws Exception {


### PR DESCRIPTION
Similar to other built-in processors.
If `true` and field does not exist or is null, the processor quietly exits without modifying the document.
https://www.elastic.co/guide/en/elasticsearch/reference/current/convert-processor.html

@spinscale 