### PR TITLE
Setup yaml rest tests manually

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,12 @@
 import java.nio.file.Files
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.gradle.api.tasks.Input;
+import org.gradle.process.CommandLineArgumentProvider;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 buildscript {
   dependencies {
@@ -22,27 +30,22 @@ version = "${elasticsearchVersion}.1-SNAPSHOT"
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'elasticsearch.esplugin'
-apply plugin: 'elasticsearch.yaml-rest-test'
+apply plugin: 'elasticsearch.testclusters'
+
 
 // license of this project
 //licenseFile = rootProject.file('LICENSE.txt')
 // copyright notices
 //noticeFile = rootProject.file('NOTICE.txt')
 
-// remove when 7.14.1 is released
-test.systemProperties 'gradle.dist.lib': "${gradle.gradleHomeDir}/lib",
-        'gradle.worker.jar': "${gradle.gradleUserHomeDir}/caches/${gradle.gradleVersion}/workerMain/gradle-worker.jar",
-        'tests.gradle': 'true',
-        'tests.task': test.path
-
 esplugin {
-  name 'ingest-langdetect'
-  description 'Ingest processor doing language detection for fields'
-  classname 'org.elasticsearch.plugin.ingest.langdetect.IngestLangDetectPlugin'
+  name = 'ingest-langdetect'
+  description = 'Ingest processor doing language detection for fields'
+  classname = 'org.elasticsearch.plugin.ingest.langdetect.IngestLangDetectPlugin'
   // license of the plugin, may be different than the above license
-  licenseFile rootProject.file('LICENSE.txt')
+  licenseFile = rootProject.file('LICENSE.txt')
   // copyright notices, may be different than the above notice
-  noticeFile rootProject.file('NOTICE.txt')
+  noticeFile = rootProject.file('NOTICE.txt')
 }
 
 //validateElasticPom.enabled = false
@@ -81,4 +84,95 @@ githubRelease.doFirst {
     tagName = currentVersion
     assets = [ filename ]
   }
+}
+
+
+// setup yaml rest tests
+testClusters {
+  yamlRestTest
+}
+
+sourceSets {
+  yamlRestTest
+}
+
+configurations {
+  yamlRestTestImplementation.extendsFrom testImplementation
+  yamlRestTestRuntimeOnly.extendsFrom testRuntimeOnly
+  restTestSpecs
+}
+
+tasks.register('copyRestTestSpecs', Copy) {
+  from zipTree(configurations.restTestSpecs.singleFile)
+  into "$buildDir/restResources/restspec"
+}
+
+TaskProvider<Zip> bundle = project.getTasks().withType(Zip.class).named("bundlePlugin");
+
+// Register rest resources with source set
+sourceSets.yamlRestTest.getOutput().dir("$buildDir/restResources/restspec");
+
+tasks.register('yamlRestTest', StandaloneRestIntegTestTask) { testTask ->
+    testTask.dependsOn(bundle, 'copyRestTestSpecs')
+
+    def cluster = testClusters.yamlRestTest
+    cluster.plugin(bundle.flatMap(AbstractArchiveTask::getArchiveFile))
+    testTask.useCluster(testClusters.yamlRestTest)
+
+    testTask.mustRunAfter(project.getTasks().named("test"))
+    testTask.setTestClassesDirs(sourceSets.yamlRestTest.getOutput().getClassesDirs())
+    testTask.setClasspath(sourceSets.yamlRestTest.getRuntimeClasspath())
+
+
+    SystemPropertyCommandLineArgumentProvider nonInputProperties = new SystemPropertyCommandLineArgumentProvider()
+    nonInputProperties.systemProperty("tests.rest.cluster", "${-> String.join(",", cluster.getAllHttpSocketURI())}")
+    nonInputProperties.systemProperty("tests.cluster", "${-> String.join(",", cluster.getAllTransportPortURI())}")
+    nonInputProperties.systemProperty("tests.clustername", "${-> cluster.getName()}")
+    testTask.getJvmArgumentProviders().add(nonInputProperties)
+    testTask.systemProperty("tests.rest.load_packaged", Boolean.FALSE.toString())
+}
+
+dependencies {
+  yamlRestTestImplementation "org.elasticsearch.test:framework:$elasticsearchVersion"
+  restTestSpecs "org.elasticsearch:rest-api-spec:$elasticsearchVersion"
+}
+
+// remove when 7.14.1 is released
+tasks.withType(Test).configureEach { testTask ->
+  testTask.systemProperties 'gradle.dist.lib': "${gradle.gradleHomeDir}/lib",
+        'gradle.worker.jar': "${gradle.gradleUserHomeDir}/caches/${gradle.gradleVersion}/workerMain/gradle-worker.jar",
+        'tests.gradle': 'true',
+        'tests.task': testTask.path
+}
+
+// This will be available in 7.15 in build tools and not manually declared. 
+public class SystemPropertyCommandLineArgumentProvider implements CommandLineArgumentProvider {
+    private final Map<String, Object> systemProperties = new LinkedHashMap<>();
+
+    public void systemProperty(String key, Supplier<String> value) {
+        systemProperties.put(key, value);
+    }
+
+    public void systemProperty(String key, Object value) {
+        systemProperties.put(key, value);
+    }
+
+    @Override
+    public Iterable<String> asArguments() {
+        return systemProperties.entrySet()
+            .stream()
+            .map(
+                entry -> "-D"
+                    + entry.getKey()
+                    + "="
+                    + (entry.getValue() instanceof Supplier ? ((Supplier) entry.getValue()).get() : entry.getValue())
+            )
+            .collect(Collectors.toList());
+    }
+
+    // Track system property keys as an input so our build cache key will change if we add properties but values are still ignored
+    @Input
+    public Iterable<String> getPropertyNames() {
+        return systemProperties.keySet();
+    }
 }


### PR DESCRIPTION
This should fix https://github.com/elastic/elasticsearch/issues/76215 for you. At the moment we have no plans to support yaml tests first class in our build-tools as there are only very few (maybe only this) external elasticsearch projects using this functionality. 
If you have any questions regarding this fix, please let me know. 